### PR TITLE
Corrected title casing

### DIFF
--- a/28Feb7am/jagsridharan-ReadMe.md
+++ b/28Feb7am/jagsridharan-ReadMe.md
@@ -1,4 +1,4 @@
-# Sharepoint Developer Community (SharePoint PnP) resources
+# SharePoint Developer Community (SharePoint PnP) resources
 
 The SharePoint Development Community (also known as the SharePoint PnP community) is an open-source initiative coordinated by SharePoint engineering. This community controls SharePoint development documentation, samples, reusable controls, and other relevant open-source initiatives related to SharePoint development.
 


### PR DESCRIPTION
Corrected the casing of "Sharepoint" to "SharePoint" in the title.

#### Category
- [x] Content fix
- [ ] New article

#### Related issues:
- fixes #47 

#### What's in this Pull Request?

Corrected the casing of "Sharepoint" to "SharePoint"