### PR TITLE
Fixed title casing

### DIFF
--- a/28Feb4pm/hugoabernier-ReadMe.md
+++ b/28Feb4pm/hugoabernier-ReadMe.md
@@ -1,4 +1,4 @@
-# Sharepoint Developer Community (SharePoint PnP) resources
+# SharePoint Developer Community (SharePoint PnP) resources
 
 The SharePoint Development Community (also known as the SharePoint PnP community) is an open-source initiative coordinated by SharePoint engineering. This community controls SharePoint development documentation, samples, reusable controls, and other relevant open-source initiatives related to SharePoint development.
 


### PR DESCRIPTION
#### Category
- [x] Content fix

#### Related issues:
- fixes #57 

#### What's in this Pull Request?

SharePoint should always use an uppercase "P"