### PR TITLE
Updated casing of Title

### DIFF
--- a/01May4pm/Ravikadri-ReadMe.md
+++ b/01May4pm/Ravikadri-ReadMe.md
@@ -1,4 +1,4 @@
-# Sharepoint Developer Community (SharePoint PnP) resources
+# SharePoint Developer Community (SharePoint PnP) resources
 
 The SharePoint Development Community (also known as the SharePoint PnP community) is an open-source initiative coordinated by SharePoint engineering. This community controls SharePoint development documentation, samples, reusable controls, and other relevant open-source initiatives related to SharePoint development.
 


### PR DESCRIPTION
Changed title casing from "Sharepoint" to "SharePoint"

#### Category
- [x] Content fix
- [ ] New article
- [ ] Example checked item (*delete this line*)

#### Related issues:
- fixes #82 

#### What's in this Pull Request?

Changed title casing from "Sharepoint" to "SharePoint"


