### PR TITLE
Fixed casing in title

### DIFF
--- a/SIC-100-FTC/2020/06-June/0618-1600/hugoabernier-ReadMe.md
+++ b/SIC-100-FTC/2020/06-June/0618-1600/hugoabernier-ReadMe.md
@@ -1,4 +1,4 @@
-# Sharepoint Developer Community (SharePoint PnP) resources
+# SharePoint Developer Community (SharePoint PnP) resources
 
 The SharePoint Development Community (also known as the SharePoint PnP community) is an open-source initiative coordinated by SharePoint engineering. This community controls SharePoint development documentation, samples, reusable controls, and other relevant open-source initiatives related to SharePoint development.
 


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article

#### Related issues:
- fixes #115

#### What's in this Pull Request?

SharePoint should always have an uppercase 'P'