### PR TITLE
Correcting casing in doc title

### DIFF
--- a/SIC-100-FTC/2020/08-August/0826-0800/PopWarner-ReadMe.md
+++ b/SIC-100-FTC/2020/08-August/0826-0800/PopWarner-ReadMe.md
@@ -1,4 +1,4 @@
-# Sharepoint Developer Community (SharePoint PnP) resources
+# SharePoint Developer Community (SharePoint PnP) resources
 
 The SharePoint Development Community (also known as the SharePoint PnP community) is an open-source initiative coordinated by SharePoint engineering. This community controls SharePoint development documentation, samples, reusable controls, and other relevant open-source initiatives related to SharePoint development.
 


### PR DESCRIPTION
#### Category
- [x] Content fix

#### Related issues:
- fixes #243

#### What's in this Pull Request?
Correcting title casing from "Sharepoint" to "SharePoint".
