### PR TITLE
Corrected casing on title

### DIFF
--- a/SIC-100-FTC/2020/09-September/0909-0400/ERDeGuzman-ReadMe.md
+++ b/SIC-100-FTC/2020/09-September/0909-0400/ERDeGuzman-ReadMe.md
@@ -1,4 +1,4 @@
-# Sharepoint Developer Community (SharePoint PnP) resources
+# SharePoint Developer Community (SharePoint PnP) resources
 
 The SharePoint Development Community (also known as the SharePoint PnP community) is an open-source initiative coordinated by SharePoint engineering. This community controls SharePoint development documentation, samples, reusable controls, and other relevant open-source initiatives related to SharePoint development.
 


### PR DESCRIPTION
#### Category
- [x] Content fix

#### Related issues:
- fixes #292 

#### What's in this Pull Request?
Changed title casing from 'Sharepoint' to 'SharePoint'
