### PR TITLE
Capitalization corrections in Title

### DIFF
--- a/SIC-100-FTC/2021/01-January/0126-1500/theresaeller-ReadMe.md
+++ b/SIC-100-FTC/2021/01-January/0126-1500/theresaeller-ReadMe.md
@@ -1,4 +1,4 @@
-# Sharepoint Developer Community (SharePoint PnP) resources
+# SharePoint Developer Community (SharePoint PnP) Resources
 
 The SharePoint Development Community (also known as the SharePoint PnP community) is an open-source initiative coordinated by SharePoint engineering. This community controls SharePoint development documentation, samples, reusable controls, and other relevant open-source initiatives related to SharePoint development.
 


### PR DESCRIPTION
Changed the lowercase p in Sharepoint to uppercase P for SharePoint
Changed the lowercase r in resources to capital R for Resources (because the rest of the words in the title are capitalized)

#### Category
- [x] Content fix
- [ ] New article

#### Related issues:
- fixes #470 

#### What's in this Pull Request?

Corrections to capitalization in the title (Sharepoint to SharePoint and resources to Resources)