### PR TITLE
Updated title casing

### DIFF
--- a/SIC-100-FTC/2021/02-Febrary/0224-0900/ManuSquall-ReadMe.md
+++ b/SIC-100-FTC/2021/02-Febrary/0224-0900/ManuSquall-ReadMe.md
@@ -1,4 +1,4 @@
-# Sharepoint Developer Community (SharePoint PnP) resources
+# SharePoint Developer Community (SharePoint PnP) resources
 
 The SharePoint Development Community (also known as the SharePoint PnP community) is an open-source initiative coordinated by SharePoint engineering. This community controls SharePoint development documentation, samples, reusable controls, and other relevant open-source initiatives related to SharePoint development.
 


### PR DESCRIPTION
Correction title form "Sharepoint" to "SharePoint"

#### Category
- [x] Content fix
- [ ] New article

#### Related issues:
- fixes #490 

#### What's in this Pull Request?
A title's correction from "Sharepoint" with a lowercase "P" to "SharePoint" with a uppercase P.

