### PR TITLE
Corrected Header Casing

### DIFF
--- a/SIC-100-FTC/2021/04-April/0427/WarnerDigital-ReadMe.md
+++ b/SIC-100-FTC/2021/04-April/0427/WarnerDigital-ReadMe.md
@@ -1,4 +1,4 @@
-# Sharepoint Developer Community (SharePoint PnP) resources
+# SharePoint Developer Community (SharePoint PnP) resources
 
 The SharePoint Development Community (also known as the SharePoint PnP community) is an open-source initiative coordinated by SharePoint engineering. This community controls SharePoint development documentation, samples, reusable controls, and other relevant open-source initiatives related to SharePoint development.
 


### PR DESCRIPTION
#### Category
- [x] Content fix
- [ ] New article

#### Related issues:
- fixes #519 


#### What's in this Pull Request?
Made a correction on the header from "Sharepoint" to "SharePoint", because SharePoint is a brand.

